### PR TITLE
feat: add improved intermediate config output options

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,9 +45,8 @@ classifiers = [
 ]
 dependencies = [
     "jinja2",
-    "PyYAML",
+    "ruamel.yaml",
     "deepmerge",
-    "types-PyYAML",
     "types-jinja2"
 ]
 


### PR DESCRIPTION
Replace PyYAML with ruamel.yaml for better comment preservation
- Remove --output config-json/yaml/yml options
- Add 3 new dump flags for config auditing:
  - --dump-env: output merged environment variables
  - --dump-confs: output templated configs to directory
  - --dump-merged: output final merged configuration
- Update test suite with comprehensive coverage
- Preserve YAML comments and formatting in dumped files

Closes #15

🤖 Generated with [Claude Code](https://claude.ai/code)